### PR TITLE
Adding a large lecture list to the resources page

### DIFF
--- a/automoderator-schedule.md
+++ b/automoderator-schedule.md
@@ -23,4 +23,6 @@ If you edit this page, you must [click this link](http://www.reddit.com/message/
 
         While you wait for answers from the community, check out the [FAQ](https://www.reddit.com/r/datascience/wiki/frequently-asked-questions) and [Resources](https://www.reddit.com/r/datascience/wiki/resources) pages on our wiki.  
 
-        ^(Last configured: 2019-02-17 09:01 AM EDT)
+        [You can also search for past weekly threads here](https://www.reddit.com/r/datascience/search?q=weekly%20thread&restrict_sr=1&t=month).
+
+        ^(Last configured: 2019-02-17 09:32 AM EDT)

--- a/resources.md
+++ b/resources.md
@@ -145,6 +145,8 @@ Below are a few that stand out, either because they are introductory courses, th
 * Yaser Abu-Mostafa's [Learning From Data](https://www.edx.org/course/caltechx/caltechx-cs1156x-learning-data-1120):
  Focuses a lot more on theory, but also doable for beginners
 
+Another resource is [this repo](https://github.com/kmario23/deep-learning-drizzle) which contains a very comprehensive list of publicly available lectures in data science, machine learning, and deep learning topics. 
+
 ---
 
 See something missing? Visit our [GitHub Repo](https://github.com/vogt4nick/datascience-wiki) and make a pull request.


### PR DESCRIPTION
The list in question is [this](https://github.com/kmario23/deep-learning-drizzle) Github repo. It was posted on /r/machinelearning a few weeks ago. I thought it might be a useful addition to the MOOC section. 